### PR TITLE
FIX: Sync minimap ray with fov_h

### DIFF
--- a/draw_minimap.c
+++ b/draw_minimap.c
@@ -46,7 +46,7 @@ void	draw_ray_line(double center[2], t_img_data *view_data, \
 	}
 }
 
-void	draw_camera_angle(t_player *player, t_img_data *view_data, int pps)
+void	draw_camera_angle(t_player *player, t_img_data *view_data, int pps, double fov_h)
 {
 	const double	camera_angle = player->camera_angle;
 	double			ray_center[2];
@@ -56,13 +56,13 @@ void	draw_camera_angle(t_player *player, t_img_data *view_data, int pps)
 
 	ray_center[X] = (player->vec_pos.x - 0.5) * pps + pps / 2 - !(pps % 2);
 	ray_center[Y] = (player->vec_pos.y - 0.5) * pps + pps / 2 - !(pps % 2);
-	ray_angle = -90.0;
-	while (ray_angle < 90.0)
+	ray_angle = -fov_h;
+	while (ray_angle < fov_h)
 	{
 		draw_ray_line(ray_center, view_data, camera_angle, ray_angle);
 		ray_angle += ray_interval;
 	}
-	draw_ray_line(ray_center, view_data, camera_angle, 90.0);
+	draw_ray_line(ray_center, view_data, camera_angle, fov_h);
 }
 
 void	draw_player(t_player *player, t_img_data *view_data, int pps)
@@ -101,5 +101,5 @@ void	draw_minimap(t_game *game)
 		y++;
 	}
 	draw_player(&game->player, &game->view_data, pps);
-	draw_camera_angle(&game->player, &game->view_data, pps);
+	draw_camera_angle(&game->player, &game->view_data, pps, game->info.fov_h);
 }


### PR DESCRIPTION
## Issue
- #23

## Changed
Minimap ray angle [-90, 90] -> sync with [-fov_h, fov_h] 